### PR TITLE
Fix uniqueness test name

### DIFF
--- a/lib/ectoplasm.ex
+++ b/lib/ectoplasm.ex
@@ -46,8 +46,13 @@ defmodule Ectoplasm do
         cs = @test_module.changeset(struct, params)
         assert cs.valid?
         __MODULE__.repository.insert!(cs)
-        {:error, cs} = __MODULE__.repository.insert(cs)
-        assert {unquote(field), {unquote(error_message), []}} in cs.errors
+
+        case __MODULE__.repository.insert(cs) do
+          {:error, cs} ->
+            assert {unquote(field), {unquote(error_message), []}} in cs.errors
+          _ -> flunk(error_message)
+        end
+
       end
     end
   end

--- a/lib/ectoplasm.ex
+++ b/lib/ectoplasm.ex
@@ -50,7 +50,7 @@ defmodule Ectoplasm do
         case __MODULE__.repository.insert(cs) do
           {:error, cs} ->
             assert {unquote(field), {unquote(error_message), []}} in cs.errors
-          _ -> flunk(unquote(field) <> " " <> unquote(error_message))
+          _ -> flunk
         end
 
       end

--- a/lib/ectoplasm.ex
+++ b/lib/ectoplasm.ex
@@ -50,7 +50,7 @@ defmodule Ectoplasm do
         case __MODULE__.repository.insert(cs) do
           {:error, cs} ->
             assert {unquote(field), {unquote(error_message), []}} in cs.errors
-          _ -> flunk(unquote(error_message))
+          _ -> flunk(unquote(field) <> " " <> unquote(error_message))
         end
 
       end

--- a/lib/ectoplasm.ex
+++ b/lib/ectoplasm.ex
@@ -50,7 +50,7 @@ defmodule Ectoplasm do
         case __MODULE__.repository.insert(cs) do
           {:error, cs} ->
             assert {unquote(field), {unquote(error_message), []}} in cs.errors
-          _ -> flunk(error_message)
+          _ -> flunk(unquote(error_message))
         end
 
       end

--- a/lib/ectoplasm.ex
+++ b/lib/ectoplasm.ex
@@ -40,7 +40,7 @@ defmodule Ectoplasm do
 
   defmacro test_unique(field, error_message \\ "has already been taken") do
     quote do
-      test "must be present" do
+      test "must be unique" do
         params = __MODULE__.valid_params()
         struct = Kernel.struct!(@test_module)
         cs = @test_module.changeset(struct, params)


### PR DESCRIPTION
Was getting duplicate test error

```
** (ExUnit.DuplicateTestError) "test crawl_uuid must be present" is already defined in Brock.CrawlTest
    (ex_unit) lib/ex_unit/case.ex:416: ExUnit.Case.register_test/4
    test/models/crawl_test.exs:19: (module)
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
    (elixir) lib/code.ex:363: Code.require_file/2
    (elixir) lib/kernel/parallel_require.ex:57: anonymous fn/2 in Kernel.ParallelRequire.spawn_requires/5
```

So I renamed the test
